### PR TITLE
Show the deprecation banner only for the PHPUnit 7 and above

### DIFF
--- a/src/FancyTestdoxPrinter.php
+++ b/src/FancyTestdoxPrinter.php
@@ -58,7 +58,7 @@ class FancyTestdoxPrinter extends ResultPrinter
         $this->colorizer = new Colorizer($this->colors);
 
         if (!static::$phpUnitIntegrationWarningHandled) {
-            if (!class_exists(\PHPUnit\Util\TestDox\CliTestDoxPrinter::class)) {
+            if (class_exists(\PHPUnit\Util\TestDox\CliTestDoxPrinter::class)) {
                 $warning = <<<WARNING
  
  !!! WARNING !!!


### PR DESCRIPTION
I think, we should show the deprecation banner only when the `\PHPUnit\Util\TestDox\CliTestDoxPrinter` class exists.